### PR TITLE
✨Game - Allow quitting chat when moving

### DIFF
--- a/game/src/scenes/main/mainScene.ts
+++ b/game/src/scenes/main/mainScene.ts
@@ -92,7 +92,7 @@ export const createMainScene = () => {
 
     // Close chat with escape
     document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && isUIOpen()) {
+      if ((e.key === "Escape" || e.key.includes("Arrow")) && isUIOpen()) {
         Game.getInstance().isGamePaused = false;
         canvas.focus();
         closeUI();


### PR DESCRIPTION
It can be sometimes annoying when  I want to quit the chat when I am full screen as I do not  want tho press escape then. Now I just need to move.